### PR TITLE
Add support for nested linking and print filename of link

### DIFF
--- a/layouts/partials/backlinks.html
+++ b/layouts/partials/backlinks.html
@@ -1,9 +1,10 @@
 {{ $bracket1 := "\\[\\[" }}
 {{ $bracket2 := "\\]\\]" }}
+{{ $fileDir := .File.Dir }}
+{{ if eq $fileDir "/" }} {{ $fileDir = "" }} {{ end }}
 {{ $filename := .File.BaseFileName }}
 
-{{ $path :=  printf "%s%s%s" $bracket1 $filename $bracket2 }}
-
+{{ $path :=  printf "%s%s%s%s" $bracket1 $fileDir $filename $bracket2 }}
 
 <ul class="backlinks">
 <h3 style="margin-top: 0px;">Backlinks</h3>

--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -1,6 +1,2 @@
 <!-- Función regex que remplaza los wikilinks por links cliclables -->
-{{ .Content | replaceRE "\\[\\[([^/]+)\\]\\]" "<a title=\"split view\" class=\"zettel-split\" href=\"${1}.html\" target=\"split\" onclick=\"openNav()\"><svg width=\"20\" height=\"20\" viewBox=\"0 0 20 20\" xmlns=\"http://www.w3.org/2000/svg\" data-svg=\"expand\"><polygon points=\"13 2 18 2 18 7 17 7 17 3 13 3\"></polygon><polygon points=\"2 13 3 13 3 17 7 17 7 18 2 18\"></polygon><path fill=\"none\" stroke=\"\" stroke-width=\"1.1\" d=\"M11,9 L17,3\"></path><path fill=\"none\" stroke=\"\" stroke-width=\"1.1\" d=\"M3,17 L9,11\"></path></svg></a><a title=\"open\" class=\"zettel-link\" href=\"${1}.html\"><svg width=\"20\" height=\"20\" viewBox=\"0 0 20 20\" xmlns=\"http://www.w3.org/2000/svg\" data-svg=\"play\"><polygon fill=\"none\" points=\"6.5,5 14.5,10 6.5,15\"></polygon></svg></a>" |safeHTML }}
-
-
-
-
+{{ .Content | replaceRE "\\[\\[(.+/?[^/]+)\\]\\]" "<a title=\"split view\" class=\"zettel-split\" href=\"${1}.html\" target=\"split\" onclick=\"openNav()\"><svg width=\"20\" height=\"20\" viewBox=\"0 0 20 20\" xmlns=\"http://www.w3.org/2000/svg\" data-svg=\"expand\"><polygon points=\"13 2 18 2 18 7 17 7 17 3 13 3\"></polygon><polygon points=\"2 13 3 13 3 17 7 17 7 18 2 18\"></polygon><path fill=\"none\" stroke=\"\" stroke-width=\"1.1\" d=\"M11,9 L17,3\"></path><path fill=\"none\" stroke=\"\" stroke-width=\"1.1\" d=\"M3,17 L9,11\"></path></svg></a><a title=\"open\" class=\"zettel-link\" href=\"${1}.html\">${1}</a>" |safeHTML }}


### PR DESCRIPTION
Made some changes to the regex so that nested wikilinks like `[[apple/pen]]` work too along with the backlinks. 

Also kind of changed the way links are rendered so let me know if you want me to remove that change. 
