### PR TITLE
Change "privado" tag finder to "private-note"

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -29,7 +29,7 @@
 			- find a better way of doing this (this is false-positive prone)
 			- code refactor
 	    -->
-			{{ $private := .Content | findRE "privado" }}
+			{{ $private := .Content | findRE "private-note" }}
 			{{ if le (len $private) 0 }}
 				{{ partial "content.html" . }}
 			{{ else }}


### PR DESCRIPTION
Hey! 
Thanks for creating this. It's very well done and it's helping me to develop a habit of writing down my notes in a public way.

I was writing a note that has the word "privado" on it and I found out about private notes. I decided to make this small change so people won't accidentally create private notes.

- Change the word "privado" (that is used in 🇪🇸 and 🇵🇹) to "private-note".
- The purpose of this is to allow people to write notes with the word "privado" without creating a private note.